### PR TITLE
修复多线程使用ArrayList可能引起的并发问题

### DIFF
--- a/src/main/java/work/yj1211/live/service/LiveRoomService.java
+++ b/src/main/java/work/yj1211/live/service/LiveRoomService.java
@@ -176,7 +176,7 @@ public class LiveRoomService{
      */
     public List<LiveRoomInfo> getRoomsByUid(String uid){
         long start = System.currentTimeMillis();
-        List<LiveRoomInfo> roomList = new ArrayList<>();
+        List<LiveRoomInfo> roomList = Collections.synchronizedList(new ArrayList<>());
         List<SimpleRoomInfo> simpleRoomInfoList = roomMapper.getRoomsByUid(uid);
         CountDownLatch countDownLatch = new CountDownLatch(simpleRoomInfoList.size());
         for(SimpleRoomInfo simpleRoomInfo : simpleRoomInfoList){


### PR DESCRIPTION
/api/live/getRoomsOn接口获取用户关注的直播间信息，使用多线程请求不同的直播源，结果会存放到同一个ArrayList，可能会导致并发安全问题，因此需要将普通的list转换为并发安全的list。